### PR TITLE
python: Don't recompile commands in wasmcoro

### DIFF
--- a/python/torii_sim_wasm/wasmcoro.py
+++ b/python/torii_sim_wasm/wasmcoro.py
@@ -81,15 +81,18 @@ class WASMCoroProcess(BaseProcess):
 				if isinstance(command, ValueCastable):
 					command = Value.cast(command)
 				if isinstance(command, Value):
-					module_code = _RHSValueCompiler.compile(self.state, command, mode = 'curr')
-					run = WASMRunner(module_code, self.state.memory, self.state.set_slot)
-					result = run()
+					if not hasattr(command, 'runner'):
+						module_code = _RHSValueCompiler.compile(self.state, command, mode = 'curr')
+						command.runner = WASMRunner(module_code, self.state.memory, self.state.set_slot)
+
+					result = command.runner()
 					response = Const.normalize(result, command.shape())
 
 				elif isinstance(command, Statement):
-					module_code = _StatementCompiler.compile(self.state, command)
-					run = WASMRunner(module_code, self.state.memory, self.state.set_slot)
-					run()
+					if not hasattr(command, 'runner'):
+						module_code = _StatementCompiler.compile(self.state, command)
+						command.runner = WASMRunner(module_code, self.state.memory, self.state.set_slot)
+					command.runner()
 
 				elif type(command) is Tick:
 					domain = command.domain


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
<!-- Filling out this template is mandatory -->

<!-- =========================== -->
<!-- DO NOT EDIT ABOVE THIS LINE -->
<!-- =========================== -->

## Detailed Description

Each time wasmcoro.run is called and command instance is Value or Statement, a new wasm module is generated and compiled. Every time a new wasm module is created, a new wasm instance is created too. Wasmtime limits these instances to 10000 so recompiling existing modules should be avoided when ever possible.


# Pull Request Checklist
<!-- These are *required* -->

* [ ] This is an API breaking change. <!-- Check this box only if this is a breaking change -->
* [x] I agree to follow the Torii [Code Of Conduct].
* [x] I've read and understand the [Contribution Guidelines] and [AI Usage Policy] for Torii and agree to follow them.
* [x] I've tested this to the best of my ability.
* [x] I've documented the change to the best my ability.

## Relevant Issues/Pull Requests/Discussions

Fixes: https://github.com/shrine-maiden-heavy-industries/torii-sim-wasm/issues/2

<!-- =========================== -->
<!-- DO NOT EDIT BELOW THIS LINE -->
<!-- =========================== -->

[Code Of Conduct]: https://github.com/shrine-maiden-heavy-industries/torii-sim-wasm/blob/main/CODE_OF_CONDUCT.md
[Contribution Guidelines]: https://github.com/shrine-maiden-heavy-industries/torii-sim-wasm/blob/main/CONTRIBUTING.md
[AI Usage Policy]: https://github.com/shrine-maiden-heavy-industries/torii-sim-wasm/blob/main/CONTRIBUTING.md#ai-usage-policy
