### PR TITLE
Add `WASMConfig` for wasmtime runtime config.

### DIFF
--- a/python/torii_sim_wasm/_wasm_engine/__init__.pyi
+++ b/python/torii_sim_wasm/_wasm_engine/__init__.pyi
@@ -1,9 +1,34 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
+from enum import Enum
+from pathlib import Path
+
 __version__: str
 
+class Backend(Enum):
+	WINCH = ...
+	CRANELIFT = ...
+
+class OptLevel(Enum):
+	NONE = ...
+	SPEED = ...
+	SPEED_AND_SIZE = ...
+
+class Profiler(Enum):
+	NONE = ...
+	JITDUMP = ...
+	PERFMAP = ...
+
+class WASMConfig:
+	def __init__(
+		self, backend: Backend = Backend.WINCH, opt_level: OptLevel = OptLevel.SPEED,
+		profiler: Profiler = Profiler.NONE, max_stack: int = 524288, coredump_on_trap: bool = False,
+		inlining: bool = False, cache_path: Path | None = None
+	) -> None:
+		...
+
 class WASMInstance():
-	def __init__(self) -> None:
+	def __init__(self, config: WASMConfig | None = None) -> None:
 		...
 
 class WASMValue():

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: BSD-2-Clause
+
+use std::path::PathBuf;
+
+use pyo3::prelude::*;
+
+#[pyclass(eq, eq_int)]
+#[derive(PartialEq, Clone)]
+#[allow(non_camel_case_types, clippy::upper_case_acronyms)]
+pub enum Backend {
+    WINCH,
+    CRANELIFT,
+}
+
+impl From<::wasmtime::Strategy> for Backend {
+    fn from(value: ::wasmtime::Strategy) -> Self {
+        match value {
+            ::wasmtime::Strategy::Cranelift => Backend::CRANELIFT,
+            _ => Backend::WINCH,
+        }
+    }
+}
+
+#[pyclass(eq, eq_int)]
+#[derive(PartialEq, Clone)]
+#[allow(non_camel_case_types, clippy::upper_case_acronyms)]
+pub enum OptLevel {
+    NONE,
+    SPEED,
+    SPEED_AND_SIZE,
+}
+
+impl From<::wasmtime::OptLevel> for OptLevel {
+    fn from(value: ::wasmtime::OptLevel) -> Self {
+        match value {
+            ::wasmtime::OptLevel::None => OptLevel::NONE,
+            ::wasmtime::OptLevel::Speed => OptLevel::SPEED,
+            ::wasmtime::OptLevel::SpeedAndSize => OptLevel::SPEED_AND_SIZE,
+            _ => OptLevel::SPEED,
+        }
+    }
+}
+
+#[pyclass(eq, eq_int)]
+#[derive(PartialEq, Clone)]
+#[allow(non_camel_case_types, clippy::upper_case_acronyms)]
+pub enum Profiler {
+    NONE,
+    JITDUMP,
+    PERFMAP,
+}
+
+impl From<::wasmtime::ProfilingStrategy> for Profiler {
+    fn from(value: ::wasmtime::ProfilingStrategy) -> Self {
+        match value {
+            ::wasmtime::ProfilingStrategy::None => Profiler::NONE,
+            ::wasmtime::ProfilingStrategy::JitDump => Profiler::JITDUMP,
+            ::wasmtime::ProfilingStrategy::PerfMap => Profiler::PERFMAP,
+            _ => Profiler::NONE,
+        }
+    }
+}
+
+#[pyclass]
+#[derive(Clone)]
+pub struct WASMConfig {
+    backend: Backend,
+    opt_level: OptLevel,
+    profiler: Profiler,
+    max_stack: usize,
+    coredump_on_trap: bool,
+    inlining: bool,
+    cache_path: Option<PathBuf>,
+}
+
+#[pymethods]
+impl WASMConfig {
+    #[new]
+    #[pyo3(signature = (
+		backend = Backend::WINCH, opt_level = OptLevel::SPEED, profiler = Profiler::NONE, max_stack = 524288,
+		coredump_on_trap = false, inlining = false, cache_path = None,
+	))]
+    #[allow(clippy::too_many_arguments)]
+    fn new(
+        backend: Backend,
+        opt_level: OptLevel,
+        profiler: Profiler,
+        max_stack: usize,
+        coredump_on_trap: bool,
+        inlining: bool,
+        cache_path: Option<PathBuf>,
+    ) -> Self {
+        WASMConfig {
+            backend,
+            opt_level,
+            profiler,
+            max_stack,
+            coredump_on_trap,
+            inlining,
+            cache_path,
+        }
+    }
+}
+
+impl Default for WASMConfig {
+    fn default() -> Self {
+        Self {
+            backend: Backend::WINCH,
+            opt_level: OptLevel::SPEED,
+            profiler: Profiler::NONE,
+            max_stack: 524288, // 512KiB
+            coredump_on_trap: false,
+            inlining: false,
+            cache_path: None,
+        }
+    }
+}
+
+impl From<WASMConfig> for ::wasmtime::Config {
+    fn from(value: WASMConfig) -> Self {
+        ::wasmtime::Config::new()
+            .max_wasm_stack(value.max_stack)
+            .wasm_memory64(true)
+            .strategy(match value.backend {
+                Backend::WINCH => ::wasmtime::Strategy::Winch,
+                Backend::CRANELIFT => ::wasmtime::Strategy::Cranelift,
+            })
+            .profiler(match value.profiler {
+                Profiler::NONE => ::wasmtime::ProfilingStrategy::None,
+                Profiler::JITDUMP => ::wasmtime::ProfilingStrategy::JitDump,
+                Profiler::PERFMAP => ::wasmtime::ProfilingStrategy::PerfMap,
+            })
+            .cranelift_opt_level(match value.opt_level {
+                OptLevel::NONE => ::wasmtime::OptLevel::None,
+                OptLevel::SPEED => ::wasmtime::OptLevel::Speed,
+                OptLevel::SPEED_AND_SIZE => ::wasmtime::OptLevel::SpeedAndSize,
+            })
+            .cranelift_regalloc_algorithm(::wasmtime::RegallocAlgorithm::SinglePass)
+            .coredump_on_trap(value.coredump_on_trap)
+            .compiler_inlining(value.inlining)
+            .cache(value.cache_path.map(|v| {
+                ::wasmtime::Cache::new(::wasmtime::CacheConfig::new().with_directory(v).to_owned())
+                    .unwrap()
+            }))
+            .to_owned()
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,19 +2,26 @@
 
 use pyo3::prelude::*;
 
+mod config;
 mod memory;
 mod runner;
 
 #[pymodule]
 #[pyo3(name = "_wasm_engine")]
 mod wasm_engine {
+    use crate::config;
     use crate::memory;
     use crate::runner;
+
     use pyo3::prelude::*;
 
     #[pymodule_init]
     fn init(m: &Bound<'_, PyModule>) -> PyResult<()> {
         m.add("__version__", env!("CARGO_PKG_VERSION"))?;
+        m.add_class::<config::Backend>()?;
+        m.add_class::<config::OptLevel>()?;
+        m.add_class::<config::Profiler>()?;
+        m.add_class::<config::WASMConfig>()?;
         m.add_class::<memory::WASMValue>()?;
         m.add_class::<memory::WASMInstance>()?;
         m.add_class::<runner::WASMRunner>()?;

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: BSD-2-Clause
 
 use pyo3::prelude::*;
-use wasmtime::{Config, Engine, Memory, MemoryTypeBuilder, Store};
+use wasmtime::{Engine, Memory, MemoryTypeBuilder, Store};
+
+use crate::config::WASMConfig;
 
 #[pyclass]
 pub struct WASMInstance {
@@ -12,10 +14,11 @@ pub struct WASMInstance {
 #[pymethods]
 impl WASMInstance {
     #[new]
-    fn new() -> Self {
-        let mut config = Config::new();
-        config.strategy(wasmtime::Strategy::Winch);
-        let engine = Engine::new(&config).unwrap();
+    #[pyo3(signature = (config = None))]
+    fn new(config: Option<WASMConfig>) -> Self {
+        let runtime_config = config.unwrap_or_default();
+
+        let engine = Engine::new(&runtime_config.into()).unwrap();
         let mut store = Store::new(&engine, ());
 
         let mem_type = MemoryTypeBuilder::new()


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
<!-- Filling out this template is mandatory -->

<!-- =========================== -->
<!-- DO NOT EDIT ABOVE THIS LINE -->
<!-- =========================== -->

## Detailed Description

This PR adds `WASMConfig` that allows for configuring the wasmtime runtime when creating new `WASMInstance`'s 

This allows us to try to tune the default performance, and also allow for setting the options from Python if we need to for things like setting the cache directory, and maybe tuning the runtime for the current system.

# Pull Request Checklist
<!-- These are *required* -->

* [ ] This is an API breaking change. <!-- Check this box only if this is a breaking change -->
* [x] I agree to follow the Torii [Code Of Conduct].
* [x] I've read and understand the [Contribution Guidelines] and [AI Usage Policy] for Torii and agree to follow them.
* [x] I've tested this to the best of my ability.
* [x] I've documented the change to the best my ability.


<!-- =========================== -->
<!-- DO NOT EDIT BELOW THIS LINE -->
<!-- =========================== -->

[Code Of Conduct]: https://github.com/shrine-maiden-heavy-industries/torii-sim-wasm/blob/main/CODE_OF_CONDUCT.md
[Contribution Guidelines]: https://github.com/shrine-maiden-heavy-industries/torii-sim-wasm/blob/main/CONTRIBUTING.md
[AI Usage Policy]: https://github.com/shrine-maiden-heavy-industries/torii-sim-wasm/blob/main/CONTRIBUTING.md#ai-usage-policy
